### PR TITLE
Update node version in action.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-  Update action to use `node20`
+
 ## [2.0.0] - 2024-02-14
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: 'The path to the changelog file. Defaults to `./CHANGELOG.md`'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Hello!

Once again I had to update the node version in the actions.yaml to avoid the warning emitted by the GitHub Actions:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

I have made sure that the action still works on my side after using node20.

Can you please merge this PR and create a new release when you can?